### PR TITLE
Housekeeping

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@size-limit/preset-small-lib": "^4.9.1",
     "@types/express": "^4.17.11",
     "@types/jsonwebtoken": "^8.5.0",
+    "@types/passport": "^1.0.5",
     "husky": "^4.3.7",
     "size-limit": "^4.9.1",
     "tsdx": "^0.14.1",
@@ -57,7 +58,6 @@
   },
   "dependencies": {
     "@types/node": "^14.14.20",
-    "@types/passport-strategy": "^0.2.35",
     "jsonwebtoken": "^8.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.9.1",
+    "@types/express": "^4.17.11",
     "@types/jsonwebtoken": "^8.5.0",
     "husky": "^4.3.7",
     "size-limit": "^4.9.1",
@@ -57,7 +58,6 @@
   "dependencies": {
     "@types/node": "^14.14.20",
     "@types/passport-strategy": "^0.2.35",
-    "jsonwebtoken": "^8.5.1",
-    "passport-strategy": "^1.0.0"
+    "jsonwebtoken": "^8.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import type { StrategyCreatedStatic } from 'passport';
 import { generateToken, decodeToken } from './token';
 
 type VerifyCallback = (
@@ -18,80 +19,70 @@ interface Options {
   verify: VerifyCallback;
 }
 
-declare class MagicLoginStrategy {
-  constructor(options: Options);
-  authenticate(req: Request): void;
-  confirm(req: Request, res: Response): void;
-  send(req: Request, res: Response): void;
-}
+class MagicLoginStrategy {
+  name: string = 'magiclogin';
 
-function MagicLoginStrategy(options: Options) {
-  this.name = 'magiclogin';
-  this.callbackUrl = options.callbackUrl;
-  this.confirmUrl = options.confirmUrl;
-  this._options = options;
-  this.send = this.send.bind(this);
-  this.confirm = this.confirm.bind(this);
-}
+  constructor(private _options: Options) { }
 
-MagicLoginStrategy.prototype.authenticate = function(req) {
-  const self = this;
-  const payload = decodeToken({
-    secret: self._options.secret,
-    token: req.query.token as string,
-  });
-  const verifyCallback = function(err?: Error, user?: Object, info?: any) {
-    if (err) {
-      return self.error(err);
-    } else if (!user) {
-      return self.fail(info);
-    } else {
-      return self.success(user, info);
-    }
-  };
-
-  self._options.verify(payload, verifyCallback);
-};
-
-MagicLoginStrategy.prototype.send = function(req: Request, res: Response) {
-  if (!req.body.destination) {
-    res.status(400).send('Please specify the destination.');
-    return;
-  }
-
-  const code = Math.floor(Math.random() * 90000) + 10000 + '';
-  const jwt = generateToken({
-    secret: this._options.secret,
-    destination: req.body.destination,
-    code,
-  });
-
-  this._options
-    .sendMagicLink(
-      req.body.destination,
-      `${this._options.confirmUrl}?token=${jwt}`,
-      code
-    )
-    .then(() => {
-      res.json({ success: true, code });
-    })
-    .catch((error: any) => {
-      console.error(error);
-      res.json({ success: false, error });
+  authenticate(this: StrategyCreatedStatic & MagicLoginStrategy, req: Request): void {
+    const self = this;
+    const payload = decodeToken({
+      secret: self._options.secret,
+      token: req.query.token as string,
     });
-};
-
-MagicLoginStrategy.prototype.confirm = function(req: Request, res: Response) {
-  const data = decodeToken({
-    token: req.query.token as string,
-    secret: this._options.secret,
-  });
-
-  if (data) {
-    res.redirect(`${this._options.callbackUrl}?token=${req.query.token}`);
-  } else {
-    res.send('Expired login link. Please try again!');
+    const verifyCallback = function(err?: Error, user?: Object, info?: any) {
+      if (err) {
+        return self.error(err);
+      } else if (!user) {
+        return self.fail(info);
+      } else {
+        return self.success(user, info);
+      }
+    };
+  
+    self._options.verify(payload, verifyCallback);
   }
-};
+
+  send = (req: Request, res: Response): void => {
+    if (!req.body.destination) {
+      res.status(400).send('Please specify the destination.');
+      return;
+    }
+  
+    const code = Math.floor(Math.random() * 90000) + 10000 + '';
+    const jwt = generateToken({
+      secret: this._options.secret,
+      destination: req.body.destination,
+      code,
+    });
+  
+    this._options
+      .sendMagicLink(
+        req.body.destination,
+        `${this._options.confirmUrl}?token=${jwt}`,
+        code
+      )
+      .then(() => {
+        res.json({ success: true, code });
+      })
+      .catch((error: any) => {
+        console.error(error);
+        res.json({ success: false, error });
+      });
+  }
+
+  confirm = (req: Request, res: Response): void => {
+    const data = decodeToken({
+      token: req.query.token as string,
+      secret: this._options.secret,
+    });
+  
+    if (data) {
+      res.redirect(`${this._options.callbackUrl}?token=${req.query.token}`);
+    } else {
+      res.send('Expired login link. Please try again!');
+    }
+  }
+}
 
 export default MagicLoginStrategy;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,5 @@
-import type { IncomingMessage, OutgoingMessage } from 'http';
-import util from 'util';
+import type { Request, Response } from 'express';
 import { generateToken, decodeToken } from './token';
-const Strategy = require('passport-strategy');
-
-interface Request extends IncomingMessage {
-  query: any;
-  body: any;
-}
-
-interface Response extends OutgoingMessage {
-  json: (body: any) => void
-  send: (body: any) => void
-  status: (statusCode: number) => Response
-  redirect(url: string): Response
-  redirect(status: number, url: string): Response
-}
 
 type VerifyCallback = (
   payload: any,
@@ -41,7 +26,6 @@ declare class MagicLoginStrategy {
 }
 
 function MagicLoginStrategy(options: Options) {
-  Strategy.call(this);
   this.name = 'magiclogin';
   this.callbackUrl = options.callbackUrl;
   this.confirmUrl = options.confirmUrl;
@@ -49,8 +33,6 @@ function MagicLoginStrategy(options: Options) {
   this.send = this.send.bind(this);
   this.confirm = this.confirm.bind(this);
 }
-
-util.inherits(MagicLoginStrategy, Strategy);
 
 MagicLoginStrategy.prototype.authenticate = function(req) {
   const self = this;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,9 +25,7 @@ it('returns some properties', () => {
         "sendMagicLink": [Function],
         "verify": [Function],
       },
-      "callbackUrl": "/auth/magiclink/callback",
       "confirm": [Function],
-      "confirmUrl": "/auth/magiclink/confirm",
       "name": "magiclogin",
       "send": [Function],
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,15 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.18"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.18.tgz#8371e260f40e0e1ca0c116a9afcd9426fa094c40"
+  integrity sha512-m4JTwx5RUBNZvky/JJ8swEJPKFd8si08pPF2PfizYjGZOKr/svUWPcoUmLow6MmPzhasphB7gSTINY67xn3JNA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
 "@types/express@*":
   version "4.17.9"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
@@ -1243,6 +1252,16 @@
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.17.11":
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
+  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
     "@types/qs" "*"
     "@types/serve-static" "*"
 
@@ -6547,11 +6566,6 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
-
-passport-strategy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
-  integrity sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=
 
 path-browserify@0.0.1:
   version "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,15 +1337,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/passport-strategy@^0.2.35":
-  version "0.2.35"
-  resolved "https://registry.yarnpkg.com/@types/passport-strategy/-/passport-strategy-0.2.35.tgz#e52f5212279ea73f02d9b06af67efe9cefce2d0c"
-  integrity sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==
-  dependencies:
-    "@types/express" "*"
-    "@types/passport" "*"
-
-"@types/passport@*":
+"@types/passport@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.5.tgz#1ff54ec3e30fa6480c5e8b8de949c6dc40ddfa2a"
   integrity sha512-wNL4kT/5rnZgyGkqX7V2qH/R/te+bklv+nXcvHzyX99vNggx9DGN+F8CEOW3P/gRi7Cjm991uidRgTHsYkSuMg==


### PR DESCRIPTION
This PR includes some code cleanup

- remove `passport-strategy` dependency as it doesn't provide anything useful
- reuse types from passport/express
- convert `MagicLoginStrategy` to use the `class` keyword for better type safety (no `declare class` needed)
- simplified the constructor by removing unused assignments, using arrow functions instead of `.bind(this)` and TypeScript's constructor assignments

Overall this removes around 20 lines of unnecessary typings, however I didn't test the changes with a working project.
Tests pass though.