### PR TITLE
Don't send the code back

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ class MagicLoginStrategy {
         req
       )
       .then(() => {
-        res.json({ success: true, code });
+        res.json({ success: true });
       })
       .catch((error: any) => {
         console.error(error);


### PR DESCRIPTION
Exposing the code to the client pauses a security risk. Furthermore it prevents using this strategy to directly send the code via email/sms instead of relying on magic links.