### PR TITLE
feat: support threading request into verify method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,8 @@ import { generateToken, decodeToken } from './token';
 
 type VerifyCallback = (
   payload: any,
-  verifyCallback: (err?: Error, user?: Object, info?: any) => void
+  verifyCallback: (err?: Error, user?: Object, info?: any) => void,
+  req: Request
 ) => void;
 
 interface Options {
@@ -47,7 +48,7 @@ class MagicLoginStrategy {
       }
     };
 
-    self._options.verify(payload, verifyCallback);
+    self._options.verify(payload, verifyCallback, req);
   }
 
   send = (req: Request, res: Response): void => {


### PR DESCRIPTION
Hi Max!

First, I love that you're actively maintaining this and providing so much value to folks. This is a very concise and clean implementation of magic links and I really appreciate you capturing it in this package.

I've grown rather fond of being able to access the request in the verify callback - a feature I've encountered in some other passport libraries (https://github.com/jaredhanson/passport-google-oauth2). I was going to file a feature request, but thought it better to come with the solution along with the request.

Let me know if this solution seems an appealing or reasonable one to you, or if this feature is unwelcome in your library. I tried to keep it minimal and non-breaking. Your time and consideration are valued regardless!

Reno