### PR TITLE
Allow POST for verification via req.body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ class MagicLoginStrategy {
     const self = this;
     const payload = decodeToken(
       self._options.secret,
-      req.query.token as string
+      (req.query.token || req.body?.token) as string
     );
 
     const verifyCallback = function(err?: Error, user?: Object, info?: any) {


### PR DESCRIPTION
Currently we need to use some query params to pass the token, but it feels more elegant to have:
`{ token: "token I got from the URL", somePayloadItem: "foobar" }`

This is especially useful when you have an intermediate UI to check the token, in my case I have a "check" page that will manually send a query to the verification callback and pass the token. I need to construct the URL with a query param while I'd rather send a POST request as we already do to send the email.