### PR TITLE
fix: Decoding errors not reported to Passport resulting in 500 error instead of 401

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,20 @@ class MagicLoginStrategy {
     req: Request
   ): void {
     const self = this;
-    const payload = decodeToken(
-      self._options.secret,
-      (req.query.token || req.body?.token) as string
-    );
+
+    let payload = null;
+
+    try {
+      payload = decodeToken(
+        self._options.secret,
+        (req.query.token || req.body?.token) as string
+      );
+    } catch (error) {
+      const defaultMessage = 'No valid token provided';
+      const message = error instanceof Error ? error.message : defaultMessage;
+
+      return self.fail(message);
+    }
 
     const verifyCallback = function(
       err?: Error | null,


### PR DESCRIPTION
When the `decodeToken` function throws an error (because the token is invalid or missing), that error is not reported to Passport with `self.fail`, this results in uncaught or 500 errors instead of the expected 401