### PR TITLE
magicLogin.create() enables creation of magic links using code instead of API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 node_modules
 dist
+lock.json
+ *-lock.yaml
+ *.lock 

--- a/package.json
+++ b/package.json
@@ -11,25 +11,23 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "tsdx watch",
-    "build": "tsdx build",
-    "test": "tsdx test",
-    "lint": "tsdx lint",
-    "prepare": "tsdx build",
+    "start": "dts watch",
+    "build": "dts build",
+    "test": "dts test",
+    "lint": "dts lint",
+    "prepare": "dts build",
     "size": "size-limit",
     "analyze": "size-limit --why"
   },
-  "peerDependencies": {},
   "husky": {
-    "hooks": {
-      "pre-commit": "tsdx lint"
-    }
+    "hooks": {}
   },
   "prettier": {
     "printWidth": 80,
     "semi": true,
     "singleQuote": true,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "endOfLine": "auto"
   },
   "name": "passport-magic-login",
   "description": "Passwordless authentication with magic links for Passport.js 🔑",
@@ -47,17 +45,17 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.9.1",
-    "@types/express": "^4.17.11",
+    "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.0",
-    "@types/passport": "^1.0.5",
-    "husky": "^4.3.7",
+    "@types/node": "^14.14.20",
+    "@types/passport": "^1.0.16",
+    "dts-cli": "^2.0.5",
+    "husky": "^9.1.3",
     "size-limit": "^4.9.1",
-    "tsdx": "^0.14.1",
     "tslib": "^2.1.0",
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@types/node": "^14.14.20",
     "jsonwebtoken": "^9.0.0"
   }
 }


### PR DESCRIPTION
This pull request resolves issue #35 by adding a new `create` method to the `MagicLoginStrategy` class that enables developers to generate magic links in code rather than having to call an API endpoint.

This method can be called with either a string or object parameter, depending how much you would like to store in the related JWT token, for example

```js
const { href, code } = magicLogin.create('my.email@foo.com');
// or
const { href, code } = magicLogin.create({ destination: 'my.email@foo.com', foo: 'bar' });
```

In addition, this pull request resolves a number of build issues caused by the outdated `tsdx` dependency, which has been replaced with the more up-to-date `dts-cli` fork.