### PR TITLE
satisfy exportable options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ type VerifyCallback = (
   req: Request
 ) => void;
 
-interface Options {
+export interface Options {
   secret: string;
   callbackUrl: string;
   jwtOptions?: SignOptions;


### PR DESCRIPTION
Typescript complains `'extends' clause of exported class 'MagicLoginStrategy' has or is using private name 'Options'.` when using this with Passport. 
Exporting `Options` unprivatises it and TS is happy.